### PR TITLE
[DM-17513] Create database and retention policies with terraform-provider-influxdb

### DIFF
--- a/charts/influxdb.yaml
+++ b/charts/influxdb.yaml
@@ -45,7 +45,7 @@ persistence:
 ## Defaults indicated below
 ##
 setDefaultUser:
-  enabled: false
+  enabled: true
 
   ## Image of the container used for job
   ## Default: appropriate/curl:latest

--- a/influxdb.tf
+++ b/influxdb.tf
@@ -52,3 +52,20 @@ data "template_file" "influxdb_values" {
     influxdb_admin_pass  = "${var.influxdb_admin_pass}"
   }
 }
+
+resource "influxdb_database" "efd" {
+  name = "efd"
+
+  retention_policies = [
+    {
+      name     = "year"
+      duration = "52w"
+      default  = "true"
+    },
+  ]
+
+  depends_on = [
+    "helm_release.nginx_ingress",
+    "helm_release.influxdb",
+  ]
+}

--- a/influxdb.tf
+++ b/influxdb.tf
@@ -65,7 +65,6 @@ resource "influxdb_database" "efd" {
   ]
 
   depends_on = [
-    "helm_release.nginx_ingress",
     "helm_release.influxdb",
   ]
 }

--- a/main.tf
+++ b/main.tf
@@ -76,3 +76,9 @@ provider "grafana" {
   url  = "https://${local.grafana_fqdn}"
   auth = "${var.grafana_admin_user}:${var.grafana_admin_pass}"
 }
+
+provider "influxdb" {
+  url      = "https://${local.dns_prefix}influxdb-${var.deploy_name}.${var.domain_name}"
+  username = "${var.influxdb_admin_user}"
+  password = "${var.influxdb_admin_pass}"
+}


### PR DESCRIPTION
We use the  [terraform-provider-influxdb](https://github.com/terraform-providers/terraform-provider-influxdb) to create the database and the retention policy for the EFD database in InfluxDB.

We forked the provider to the `lsst-sqre` org and solved this [this issue](https://github.com/terraform-providers/terraform-provider-influxdb/issues/9), otherwise, the provider would assume that InfluxDB is already provisioned which is not the case. Because of that, we had to build and install the provider as a local plugin following these steps:

```
mkdir -p $GOPATH/src/github.com/terraform-providers; cd $GOPATH/src/github.com/terraform-providers

git clone https://github.com/lsst-sqre/terraform-provider-influxdb.git

git checkout tickets/DM-17513
```

Build the provider:
```
make build
```

Copy the binary file to the terraform plugins path:
```
mkdir ~/.terraform.d/plugins
cp  $GOPATH/bin/terraform-provider-influxdb ~/.terraform.d/plugins/
```

Make sure to run
```
terragrunt init --terragrunt-source-update
```

There's an annoying message the first time you run ```terragrunt apply``` that goes away the second time but seems harmless:

```
invalid character '<' looking for the beginning of value.
```