### PR TITLE
[DM-17531] Custom configuration for confluent-kafka

### DIFF
--- a/charts/cp-helm-charts-values.yaml
+++ b/charts/cp-helm-charts-values.yaml
@@ -18,11 +18,11 @@ cp-zookeeper:
     ## production servers this number should likely be much larger.
     ##
     ## Size for Data dir, where ZooKeeper will store the in-memory database snapshots.
-    dataDirSize: 5Gi
+    dataDirSize: 15Gi
     # dataDirStorageClass: ""
 
     ## Size for data log dir, which is a dedicated log device to be used, and helps avoid competition between logging and snaphots.
-    dataLogDirSize: 5Gi
+    dataLogDirSize: 15Gi
     # dataLogDirStorageClass: ""
   resources: {}
   ## If you do want to specify resources, uncomment the following lines, adjust them as necessary,
@@ -50,7 +50,8 @@ cp-kafka:
   persistence:
     enabled: true
     # storageClass: ""
-    size: 5Gi
+    size: 15Gi
+    disksPerBroker: 1
   resources: {}
   ## If you do want to specify resources, uncomment the following lines, adjust them as necessary,
   ## and remove the curly braces after 'resources:'
@@ -60,6 +61,12 @@ cp-kafka:
   #  requests:
   #   cpu: 100m
   #   memory: 128Mi
+
+  ## Kafka Server properties
+  ## ref: https://kafka.apache.org/documentation/#configuration
+  configurationOverrides:
+    offsets.retention.minutes: 1440
+    log.retention.hours: 24
 
 ## ------------------------------------------------------
 ## Schema Registry
@@ -94,6 +101,7 @@ cp-kafka-rest:
   ## https://kubernetes.io/docs/concepts/containers/images/#specifying-imagepullsecrets-on-a-pod
   imagePullSecrets:
   #  - name: "regcred"
+  heapOptions: "-Xms512M -Xmx512M"
   resources: {}
   ## If you do want to specify resources, uncomment the following lines, adjust them as necessary,
   ## and remove the curly braces after 'resources:'
@@ -110,14 +118,13 @@ cp-kafka-rest:
 cp-kafka-connect:
   enabled: true
   image: lsstsqre/cp-kafka-connect
-  imageTag: latest
+  imageTag: tickets-DM-16846
   ## Optionally specify an array of imagePullSecrets. Secrets must be manually created in the namespace.
   ## https://kubernetes.io/docs/concepts/containers/images/#specifying-imagepullsecrets-on-a-pod
   imagePullSecrets:
   #  - name: "regcred"
 
-  pluginPath: "/usr/share/java,/etc/landoop/jars/lib"
-
+  heapOptions: "-Xms512M -Xmx512M"
   resources: {}
   ## If you do want to specify resources, uncomment the following lines, adjust them as necessary,
   ## and remove the curly braces after 'resources:'
@@ -127,6 +134,9 @@ cp-kafka-connect:
   #  requests:
   #   cpu: 100m
   #   memory: 128Mi
+
+  configurationOverrides:
+    "plugin.path": "/usr/share/java,/etc/landoop/jars/lib"
 
 ## ------------------------------------------------------
 ## KSQL Server
@@ -139,5 +149,6 @@ cp-ksql-server:
   ## https://kubernetes.io/docs/concepts/containers/images/#specifying-imagepullsecrets-on-a-pod
   imagePullSecrets:
   #  - name: "regcred"
+  heapOptions: "-Xms512M -Xmx512M"
   ksql:
     headless: false

--- a/charts/cp-helm-charts-values.yaml
+++ b/charts/cp-helm-charts-values.yaml
@@ -118,7 +118,7 @@ cp-kafka-rest:
 cp-kafka-connect:
   enabled: true
   image: lsstsqre/cp-kafka-connect
-  imageTag: tickets-DM-16846
+  imageTag: latest
   ## Optionally specify an array of imagePullSecrets. Secrets must be manually created in the namespace.
   ## https://kubernetes.io/docs/concepts/containers/images/#specifying-imagepullsecrets-on-a-pod
   imagePullSecrets:

--- a/kafka.tf
+++ b/kafka.tf
@@ -14,6 +14,7 @@ resource "helm_release" "confluent" {
   repository = "${helm_repository.confluentinc.metadata.0.name}"
   chart      = "cp-helm-charts"
   namespace  = "${kubernetes_namespace.kafka.metadata.0.name}"
+  version    = "0.1.1"
 
   keyring       = ""
   force_update  = true


### PR DESCRIPTION
Add custom configuration for `cp-helm-charts`. 

Note that this PR required an upodate of the `cp-helm-charts` chart in  https://github.com/lsst-sqre/cp-helm-charts/pull/1

To test these changes make sure to temporarily change the repository URL in `kafka.tf` to:
```
resource "helm_repository" "confluentinc" {
  name = "confluentinc"
  url  = "https://raw.githubusercontent.com/lsst-sqre/cp-helm-charts/tickets/DM-17531"
}
```

and in your `terraform.tvars` to:

```
    # the helm.helm_repository resource DOES NOT handle the repo existing in
    # the tf state but not existing in the local helm repo config.

    before_hook "3_helm_repo_add" {
      commands = ["${get_terraform_commands_that_need_locking()}"]

      execute = [
        "helm", "repo", "add", "confluentinc",
        "https://raw.githubusercontent.com/lsst-sqre/cp-helm-charts/tickets/DM-17531",
      ]

      run_on_error = false
    }
```

More information in the ticket description.