### PR TITLE
[DM-19745] Single machine deployment of the DM-EFD using k3s ("kubes")

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,14 +27,13 @@ terragrunt = {
 |------|-------------|:----:|:-----:|:-----:|
 | aws\_zone\_id | route53 Hosted Zone ID to manage DNS records in. | string | n/a | yes |
 | brokers\_disk\_size | Disk size for the cp-kafka brokers. | string | `"15Gi"` | no |
+| config\_path | Path to the kube config file. Can be sourced from KUBE_CONFIG or KUBECONFIG. | string | `"~/.kube/config"` | no |
 | deploy\_name | Name of deployment. | string | `"efd-kafka"` | no |
 | dns\_enable | create route53 dns records. | string | `"false"` | no |
 | domain\_name | DNS domain name to use when creating route53 records. | string | n/a | yes |
 | env\_name | Name of deployment environment. | string | n/a | yes |
 | github\_token | GitHub personal access token for authenticating to the GitHub API | string | n/a | yes |
 | github\_user | GitHub username for authenticating to the GitHub API. | string | n/a | yes |
-| gke\_version | gke master/node version | string | `"latest"` | no |
-| google\_project | google cloud project ID | string | n/a | yes |
 | grafana\_admin\_pass | grafana admin account passphrase. | string | n/a | yes |
 | grafana\_admin\_user | grafana admin account name. | string | `"admin"` | no |
 | grafana\_oauth\_client\_id | github oauth Client ID for grafana | string | n/a | yes |
@@ -44,7 +43,6 @@ terragrunt = {
 | influxdb\_admin\_user | influxdb admin account name. | string | `"admin"` | no |
 | influxdb\_telegraf\_pass | InfluxDB password for the telegraf user. | string | n/a | yes |
 | initial\_node\_count | number of gke nodes to start | string | `"3"` | no |
-| machine\_type | machine type of default gke pool nodes | string | `"n1-standard-2"` | no |
 | tls\_crt\_path | wildcard tls certificate. | string | n/a | yes |
 | tls\_key\_path | wildcard tls private key. | string | n/a | yes |
 | zookeeper\_data\_dir\_size | Size for Data dir, where ZooKeeper will store the in-memory database snapshots. | string | `"15Gi"` | no |

--- a/README.md
+++ b/README.md
@@ -41,8 +41,10 @@ terragrunt = {
 | grafana\_oauth\_team\_ids | github team id (integer value treated as string) | string | n/a | yes |
 | influxdb\_admin\_pass | influxdb admin account passphrase. | string | n/a | yes |
 | influxdb\_admin\_user | influxdb admin account name. | string | `"admin"` | no |
+| influxdb\_disk\_size | Disk size for InfluxDB. | string | `"128Gi"` | no |
 | influxdb\_telegraf\_pass | InfluxDB password for the telegraf user. | string | n/a | yes |
 | initial\_node\_count | number of gke nodes to start | string | `"3"` | no |
+| storage\_class | Storage class to be used for all persistent disks. For a deployment on k3s use 'local-path'. | string | `"pd-ssd"` | no |
 | tls\_crt\_path | wildcard tls certificate. | string | n/a | yes |
 | tls\_key\_path | wildcard tls private key. | string | n/a | yes |
 | zookeeper\_data\_dir\_size | Size for Data dir, where ZooKeeper will store the in-memory database snapshots. | string | `"15Gi"` | no |

--- a/charts/cp-helm-charts-values.yaml
+++ b/charts/cp-helm-charts-values.yaml
@@ -19,11 +19,11 @@ cp-zookeeper:
     ##
     ## Size for Data dir, where ZooKeeper will store the in-memory database snapshots.
     dataDirSize: ${zookeeper_data_dir_size}
-    dataDirStorageClass: "pd-ssd"
+    dataDirStorageClass: ${storage_class}
 
     ## Size for data log dir, which is a dedicated log device to be used, and helps avoid competition between logging and snaphots.
     dataLogDirSize: ${zookeeper_log_dir_size}
-    dataLogDirStorageClass: "pd-ssd"
+    dataLogDirStorageClass: ${storage_class}
   resources: {}
   ## If you do want to specify resources, uncomment the following lines, adjust them as necessary,
   ## and remove the curly braces after 'resources:'
@@ -49,7 +49,7 @@ cp-kafka:
   heapOptions: "-Xms512M -Xmx512M"
   persistence:
     enabled: true
-    storageClass: "pd-ssd"
+    storageClass: ${storage_class}
     size: ${brokers_disk_size}
     disksPerBroker: 1
   resources: {}

--- a/charts/grafana.yaml
+++ b/charts/grafana.yaml
@@ -4,6 +4,7 @@
 # Add a persistent volume to maintain dashboards between restarts
 persistence:
   enabled: true
+  storageClassName: ${storage_class}
   size: 1Gi
   accessModes:
     - ReadWriteOnce

--- a/charts/influxdb.yaml
+++ b/charts/influxdb.yaml
@@ -37,9 +37,9 @@ persistence:
   ##   set, choosing the default provisioner.  (gp2 on AWS, standard on
   ##   GKE, AWS & OpenStack)
   ##
-  storageClass: "pd-ssd"
+  storageClass: ${storage_class}
   accessMode: ReadWriteOnce
-  size: 128Gi
+  size: ${influxdb_disk_size}
 
 ## Create default user through Kubernetes job
 ## Defaults indicated below

--- a/charts/prometheus.yaml
+++ b/charts/prometheus.yaml
@@ -1,5 +1,36 @@
 ---
+alertmanager:
+  ## If false, alertmanager will not be installed
+  ##
+  persistentVolume:
+    ## If true, alertmanager will create/use a Persistent Volume Claim
+    ## If false, use emptyDir
+    ##
+    enabled: true
+
+    ## alertmanager data Persistent Volume access modes
+    ## Must match those of existing PV or dynamic provisioner
+    ## Ref: http://kubernetes.io/docs/user-guide/persistent-volumes/
+    ##
+    accessModes:
+      - ReadWriteOnce
+    storageClass: ${storage_class}
+
 server:
+  persistentVolume:
+    ## If true, alertmanager will create/use a Persistent Volume Claim
+    ## If false, use emptyDir
+    ##
+    enabled: true
+
+    ## pushgateway data Persistent Volume access modes
+    ## Must match those of existing PV or dynamic provisioner
+    ## Ref: http://kubernetes.io/docs/user-guide/persistent-volumes/
+    ##
+    accessModes:
+      - ReadWriteOnce
+    storageClass: ${storage_class}
+
   service:
     # ingress on gke requires "NodePort" or "LoadBalancer"
     type: NodePort

--- a/charts/telegraf.yaml
+++ b/charts/telegraf.yaml
@@ -8,7 +8,7 @@ image:
 ## Configure the telegraf daemonset here.
 ## Resource limits and outputs can be set separately
 daemonset:
-  enabled: true
+  enabled: false
   ## Configure resource requests and limits
   ## ref: http://kubernetes.io/docs/user-guide/compute-resources/
   resources:

--- a/grafana.tf
+++ b/grafana.tf
@@ -54,6 +54,7 @@ data "template_file" "grafana_values" {
     client_id                = "${var.grafana_oauth_client_id}"
     client_secret            = "${var.grafana_oauth_client_secret}"
     team_ids                 = "${var.grafana_oauth_team_ids}"
+    storage_class            = "${var.storage_class}"
   }
 }
 

--- a/influxdb.tf
+++ b/influxdb.tf
@@ -50,6 +50,8 @@ data "template_file" "influxdb_values" {
     influxdb_secret_name = "${local.influxdb_secret_name}"
     influxdb_admin_user  = "${var.influxdb_admin_user}"
     influxdb_admin_pass  = "${var.influxdb_admin_pass}"
+    storage_class        = "${var.storage_class}"
+    influxdb_disk_size   = "${var.influxdb_disk_size}"
   }
 }
 

--- a/kafka.tf
+++ b/kafka.tf
@@ -38,6 +38,7 @@ data "template_file" "cp-helm-charts-values" {
     brokers_disk_size       = "${var.brokers_disk_size}"
     zookeeper_data_dir_size = "${var.zookeeper_data_dir_size}"
     zookeeper_log_dir_size  = "${var.zookeeper_log_dir_size}"
+    storage_class           = "${var.storage_class}"
   }
 }
 

--- a/main.tf
+++ b/main.tf
@@ -2,46 +2,13 @@ provider "template" {
   version = "~> 1.0"
 }
 
-provider "google" {
-  version = "~> 1.20"
-}
-
 provider "null" {
   version = "~> 1.0"
 }
 
-module "gke" {
-  source = "git::https://github.com/lsst-sqre/terraform-gke-std.git//?ref=master"
-
-  name               = "${local.gke_cluster_name}"
-  google_project     = "${var.google_project}"
-  gke_version        = "${var.gke_version}"
-  initial_node_count = "${var.initial_node_count}"
-  machine_type       = "${var.machine_type}"
-}
-
-# haxx...
-resource "null_resource" "gcloud_container_clusters_get-credentials" {
-  triggers = {
-    google_container_cluster_endpoint = "${module.gke.id}"
-  }
-
-  provisioner "local-exec" {
-    command = "gcloud container clusters get-credentials ${local.gke_cluster_name}"
-  }
-
-  depends_on = [
-    "module.gke",
-  ]
-}
-
 provider "kubernetes" {
-  version = "~> 1.4.0"
-
-  load_config_file = true
-
-  host                   = "${module.gke.host}"
-  cluster_ca_certificate = "${base64decode(module.gke.cluster_ca_certificate)}"
+  version     = "~> 1.4.0"
+  config_path = "${var.config_path}"
 }
 
 module "tiller" {
@@ -60,8 +27,7 @@ provider "helm" {
   install_tiller  = false
 
   kubernetes {
-    host                   = "${module.gke.host}"
-    cluster_ca_certificate = "${base64decode(module.gke.cluster_ca_certificate)}"
+    config_path = "${var.config_path}"
   }
 }
 

--- a/prometheus.tf
+++ b/prometheus.tf
@@ -34,6 +34,7 @@ data "template_file" "prometheus_values" {
 
   vars {
     prometheus_fqdn = "${local.prometheus_fqdn}"
+    storage_class   = "${var.storage_class}"
   }
 }
 

--- a/variables.tf
+++ b/variables.tf
@@ -1,5 +1,6 @@
-variable "google_project" {
-  description = "google cloud project ID"
+variable "config_path" {
+  description = "Path to the kube config file. Can be sourced from KUBE_CONFIG or KUBECONFIG."
+  default     = "~/.kube/config"
 }
 
 variable "env_name" {
@@ -58,22 +59,9 @@ variable "initial_node_count" {
   default     = 3
 }
 
-variable "gke_version" {
-  description = "gke master/node version"
-  default     = "latest"
-}
-
-variable "machine_type" {
-  description = "machine type of default gke pool nodes"
-  default     = "n1-standard-2"
-}
-
 locals {
   # remove "<env>-" prefix for production
   dns_prefix = "${replace("${var.env_name}-", "prod-", "")}"
-
-  # Name of google cloud container cluster to deploy into
-  gke_cluster_name = "${var.deploy_name}-${var.env_name}"
 
   prometheus_k8s_namespace     = "prometheus"
   kafka_k8s_namespace          = "kafka"

--- a/variables.tf
+++ b/variables.tf
@@ -91,6 +91,11 @@ variable "github_token" {
   description = "GitHub personal access token for authenticating to the GitHub API"
 }
 
+variable "influxdb_disk_size" {
+  description = "Disk size for InfluxDB."
+  default     = "128Gi"
+}
+
 variable "brokers_disk_size" {
   description = "Disk size for the cp-kafka brokers."
   default     = "15Gi"
@@ -108,4 +113,9 @@ variable "zookeeper_log_dir_size" {
 
 variable "influxdb_telegraf_pass" {
   description = "InfluxDB password for the telegraf user."
+}
+
+variable "storage_class" {
+  description = "Storage class to be used for all persistent disks. For a deployment on k3s use 'local-path'."
+  default     = "pd-ssd"
 }


### PR DESCRIPTION
- Assume the cluster already exists and use `config_path` to connect to the cluster
- Specify the storage class to be used to create persistent volumes
