### PR TITLE
[DM-19745] Single machine deployment of the DM-EFD using k3s ("kubes")

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,7 @@ module "efd" {
 | dns\_enable | create route53 dns records. | string | `"false"` | no |
 | dns\_overwrite | overwrite pre-existing DNS records. | string | `"false"` | no |
 | domain\_name | DNS domain name to use when creating route53 records. | string | n/a | yes |
+| enable\_telegraf\_daemonset | If true Telegraf client will run on all nodes. Set false for k3s single node deployment. | string | `"true"` | no |
 | env\_name | Name of deployment environment. | string | n/a | yes |
 | github\_token | GitHub personal access token for authenticating to the GitHub API | string | n/a | yes |
 | github\_user | GitHub username for authenticating to the GitHub API. | string | n/a | yes |

--- a/README.md
+++ b/README.md
@@ -84,6 +84,7 @@ module "efd" {
 | grafana\_oauth\_team\_ids | github team id (integer value treated as string) | string | n/a | yes |
 | influxdb\_admin\_pass | influxdb admin account passphrase. | string | n/a | yes |
 | influxdb\_admin\_user | influxdb admin account name. | string | `"admin"` | no |
+| influxdb\_disk\_size | Disk size for InfluxDB. | string | `"128Gi"` | no |
 | influxdb\_telegraf\_pass | InfluxDB password for the telegraf user. | string | n/a | yes |
 | kubeconfig\_filename | kubeconfig file to configure kubernetes/helm providers | string | n/a | yes |
 | prometheus\_oauth\_client\_id | github oauth client id | string | n/a | yes |

--- a/README.md
+++ b/README.md
@@ -87,6 +87,7 @@ module "efd" {
 | influxdb\_admin\_user | influxdb admin account name. | string | `"admin"` | no |
 | influxdb\_disk\_size | Disk size for InfluxDB. | string | `"128Gi"` | no |
 | influxdb\_telegraf\_pass | InfluxDB password for the telegraf user. | string | n/a | yes |
+| kafka\_loadbalancers | Number of Kafka loadbalancers. Must be less or equal to the number of Kafka brokers. Set to 1 for single node deployment with k3s. | string | `"3"` | no |
 | kubeconfig\_filename | kubeconfig file to configure kubernetes/helm providers | string | n/a | yes |
 | prometheus\_oauth\_client\_id | github oauth client id | string | n/a | yes |
 | prometheus\_oauth\_client\_secret | github oauth client secret | string | n/a | yes |
@@ -101,9 +102,7 @@ module "efd" {
 
 | Name | Description |
 |------|-------------|
-| confluent\_lb0 |  |
-| confluent\_lb1 |  |
-| confluent\_lb2 |  |
+| confluent\_lb\_ips |  |
 | grafana\_fqdn |  |
 | influxdb\_fqdn |  |
 | nginx\_ingress\_ip |  |

--- a/README.md
+++ b/README.md
@@ -89,6 +89,7 @@ module "efd" {
 | prometheus\_oauth\_client\_id | github oauth client id | string | n/a | yes |
 | prometheus\_oauth\_client\_secret | github oauth client secret | string | n/a | yes |
 | prometheus\_oauth\_github\_org | limit access to prometheus dashboard to members of this org | string | n/a | yes |
+| storage\_class | Storage class to be used for all persistent disks. For a deployment on k3s use 'local-path'. | string | `"pd-ssd"` | no |
 | tls\_crt\_path | wildcard tls certificate. | string | n/a | yes |
 | tls\_key\_path | wildcard tls private key. | string | n/a | yes |
 | zookeeper\_data\_dir\_size | Size for Data dir, where ZooKeeper will store the in-memory database snapshots. | string | `"15Gi"` | no |

--- a/charts/cp-helm-charts-values.yaml
+++ b/charts/cp-helm-charts-values.yaml
@@ -40,6 +40,7 @@ cp-zookeeper:
 cp-kafka:
   enabled: true
   brokers: 3
+  loadbalancers: ${kafka_loadbalancers}
   image: confluentinc/cp-kafka
   imageTag: 5.0.1
   ## Optionally specify an array of imagePullSecrets. Secrets must be manually created in the namespace.

--- a/charts/cp-helm-charts-values.yaml
+++ b/charts/cp-helm-charts-values.yaml
@@ -19,11 +19,11 @@ cp-zookeeper:
     ##
     ## Size for Data dir, where ZooKeeper will store the in-memory database snapshots.
     dataDirSize: ${zookeeper_data_dir_size}
-    dataDirStorageClass: "pd-ssd"
+    dataDirStorageClass: ${storage_class}
 
     ## Size for data log dir, which is a dedicated log device to be used, and helps avoid competition between logging and snaphots.
     dataLogDirSize: ${zookeeper_log_dir_size}
-    dataLogDirStorageClass: "pd-ssd"
+    dataLogDirStorageClass: ${storage_class}
   resources: {}
   ## If you do want to specify resources, uncomment the following lines, adjust them as necessary,
   ## and remove the curly braces after 'resources:'
@@ -49,7 +49,7 @@ cp-kafka:
   heapOptions: "-Xms512M -Xmx512M"
   persistence:
     enabled: true
-    storageClass: "pd-ssd"
+    storageClass: ${storage_class}
     size: ${brokers_disk_size}
     disksPerBroker: 1
   resources: {}

--- a/charts/influxdb.yaml
+++ b/charts/influxdb.yaml
@@ -40,7 +40,7 @@ persistence:
   ##
   storageClass: ${storage_class}
   accessMode: ReadWriteOnce
-  size: 128Gi
+  size: ${influxdb_disk_size}
 
 ## Create default user through Kubernetes job
 ## Defaults indicated below

--- a/charts/influxdb.yaml
+++ b/charts/influxdb.yaml
@@ -38,7 +38,7 @@ persistence:
   ##   set, choosing the default provisioner.  (gp2 on AWS, standard on
   ##   GKE, AWS & OpenStack)
   ##
-  storageClass: "pd-ssd"
+  storageClass: ${storage_class}
   accessMode: ReadWriteOnce
   size: 128Gi
 

--- a/charts/prometheus-operator.yaml
+++ b/charts/prometheus-operator.yaml
@@ -1,6 +1,27 @@
 ---
+alertmanager:
+  alertmanagerSpec:
+    storage:
+      volumeClaimTemplate:
+        spec:
+          storageClassName: ${storage_class}
+          accessModes: ["ReadWriteOnce"]
+          resources:
+            requests:
+              storage: 50Gi
+        selector: {}
+
 prometheus:
   prometheusSpec:
+    storageSpec:
+      volumeClaimTemplate:
+        spec:
+          storageClassName: ${storage_class}
+          accessModes: ["ReadWriteOnce"]
+          resources:
+            requests:
+              storage: 50Gi
+        selector: {}
     # select all serviceMonitors
     serviceMonitorSelectorNilUsesHelmValues: false
     serviceMonitorSelector: {}
@@ -50,6 +71,7 @@ grafana:
   # Add a persistent volume to maintain dashboards between restarts
   persistence:
     enabled: true
+    storageClassName: ${storage_class}
     size: 1Gi
     accessModes:
       - ReadWriteOnce

--- a/charts/telegraf.yaml
+++ b/charts/telegraf.yaml
@@ -9,7 +9,7 @@ image:
 ## Configure the telegraf daemonset here.
 ## Resource limits and outputs can be set separately
 daemonset:
-  enabled: true
+  enabled: ${enable_telegraf_daemonset}
   ## Configure resource requests and limits
   ## ref: http://kubernetes.io/docs/user-guide/compute-resources/
   resources:

--- a/influxdb.tf
+++ b/influxdb.tf
@@ -52,6 +52,7 @@ data "template_file" "influxdb_values" {
     influxdb_admin_user  = "${var.influxdb_admin_user}"
     influxdb_admin_pass  = "${var.influxdb_admin_pass}"
     storage_class        = "${var.storage_class}"
+    influxdb_disk_size   = "${var.influxdb_disk_size}"
   }
 }
 

--- a/influxdb.tf
+++ b/influxdb.tf
@@ -51,6 +51,7 @@ data "template_file" "influxdb_values" {
     influxdb_secret_name = "${local.influxdb_secret_name}"
     influxdb_admin_user  = "${var.influxdb_admin_user}"
     influxdb_admin_pass  = "${var.influxdb_admin_pass}"
+    storage_class        = "${var.storage_class}"
   }
 }
 

--- a/kafka.tf
+++ b/kafka.tf
@@ -42,6 +42,7 @@ data "template_file" "cp-helm-charts-values" {
     domain_name             = "${var.domain_name}"
     zookeeper_data_dir_size = "${var.zookeeper_data_dir_size}"
     zookeeper_log_dir_size  = "${var.zookeeper_log_dir_size}"
+    storage_class           = "${var.storage_class}"
   }
 }
 

--- a/kafka.tf
+++ b/kafka.tf
@@ -18,7 +18,7 @@ resource "helm_release" "confluent" {
   repository = "${helm_repository.confluentinc.metadata.0.name}"
   chart      = "cp-helm-charts"
   namespace  = "${kubernetes_namespace.kafka.metadata.0.name}"
-  version    = "0.1.1"
+  version    = "0.1.2"
 
   force_update  = true
   recreate_pods = true
@@ -43,30 +43,15 @@ data "template_file" "cp-helm-charts-values" {
     zookeeper_data_dir_size = "${var.zookeeper_data_dir_size}"
     zookeeper_log_dir_size  = "${var.zookeeper_log_dir_size}"
     storage_class           = "${var.storage_class}"
+    kafka_loadbalancers     = "${var.kafka_loadbalancers}"
   }
 }
 
-data "kubernetes_service" "lb0" {
+data "kubernetes_service" "lb" {
+  count = "${var.kafka_loadbalancers}"
+
   metadata {
-    name      = "confluent-0-loadbalancer"
-    namespace = "${kubernetes_namespace.kafka.metadata.0.name}"
-  }
-
-  depends_on = ["helm_release.confluent"]
-}
-
-data "kubernetes_service" "lb1" {
-  metadata {
-    name      = "confluent-1-loadbalancer"
-    namespace = "${kubernetes_namespace.kafka.metadata.0.name}"
-  }
-
-  depends_on = ["helm_release.confluent"]
-}
-
-data "kubernetes_service" "lb2" {
-  metadata {
-    name      = "confluent-2-loadbalancer"
+    name      = "confluent-${count.index}-loadbalancer"
     namespace = "${kubernetes_namespace.kafka.metadata.0.name}"
   }
 
@@ -74,7 +59,5 @@ data "kubernetes_service" "lb2" {
 }
 
 locals {
-  confluent_lb0_ip = "${lookup(data.kubernetes_service.lb0.load_balancer_ingress[0], "ip")}"
-  confluent_lb1_ip = "${lookup(data.kubernetes_service.lb1.load_balancer_ingress[0], "ip")}"
-  confluent_lb2_ip = "${lookup(data.kubernetes_service.lb2.load_balancer_ingress[0], "ip")}"
+  confluent_lb_ips = ["${data.kubernetes_service.lb.0.load_balancer_ingress.0.ip}"]
 }

--- a/outputs.tf
+++ b/outputs.tf
@@ -1,13 +1,5 @@
-output "confluent_lb0" {
-  value = "${local.confluent_lb0_ip}"
-}
-
-output "confluent_lb1" {
-  value = "${local.confluent_lb1_ip}"
-}
-
-output "confluent_lb2" {
-  value = "${local.confluent_lb2_ip}"
+output "confluent_lb_ips" {
+  value = "${local.confluent_lb_ips}"
 }
 
 output "nginx_ingress_ip" {

--- a/prometheus-operator.tf
+++ b/prometheus-operator.tf
@@ -42,6 +42,7 @@ data "template_file" "prometheus_operator_values" {
     prometheus_k8s_namespace = "${kubernetes_namespace.prometheus.metadata.0.name}"
     prometheus_secret_name   = "${kubernetes_secret.prometheus_tls.metadata.0.name}"
     team_ids                 = "${var.grafana_oauth_team_ids}"
+    storage_class            = "${var.storage_class}"
   }
 }
 

--- a/route53.tf
+++ b/route53.tf
@@ -1,34 +1,12 @@
-resource "aws_route53_record" "kafka_lb0" {
-  count           = "${var.dns_enable ? 1 : 0}"
+resource "aws_route53_record" "kafka_lb" {
+  count           = "${var.dns_enable ? var.kafka_loadbalancers : 0}"
   zone_id         = "${var.aws_zone_id}"
   allow_overwrite = "${var.dns_overwrite}"
 
-  name    = "${local.dns_prefix}${var.deploy_name}0.${var.domain_name}"
+  name    = "${local.dns_prefix}${var.deploy_name}${count.index}.${var.domain_name}"
   type    = "A"
   ttl     = "60"
-  records = ["${local.confluent_lb0_ip}"]
-}
-
-resource "aws_route53_record" "kafka_lb1" {
-  count           = "${var.dns_enable ? 1 : 0}"
-  zone_id         = "${var.aws_zone_id}"
-  allow_overwrite = "${var.dns_overwrite}"
-
-  name    = "${local.dns_prefix}${var.deploy_name}1.${var.domain_name}"
-  type    = "A"
-  ttl     = "60"
-  records = ["${local.confluent_lb1_ip}"]
-}
-
-resource "aws_route53_record" "kafka_lb2" {
-  count           = "${var.dns_enable ? 1 : 0}"
-  zone_id         = "${var.aws_zone_id}"
-  allow_overwrite = "${var.dns_overwrite}"
-
-  name    = "${local.dns_prefix}${var.deploy_name}2.${var.domain_name}"
-  type    = "A"
-  ttl     = "60"
-  records = ["${local.confluent_lb2_ip}"]
+  records = ["${element(local.confluent_lb_ips, count.index)}"]
 }
 
 resource "aws_route53_record" "grafana" {

--- a/telegraf.tf
+++ b/telegraf.tf
@@ -34,7 +34,8 @@ data "template_file" "telegraf_values" {
   template = "${file("${path.module}/charts/telegraf.yaml")}"
 
   vars {
-    influxdb_url           = "${local.influxdb_url}"
-    influxdb_telegraf_pass = "${var.influxdb_telegraf_pass}"
+    influxdb_url              = "${local.influxdb_url}"
+    influxdb_telegraf_pass    = "${var.influxdb_telegraf_pass}"
+    enable_telegraf_daemonset = "${var.enable_telegraf_daemonset}"
   }
 }

--- a/variables.tf
+++ b/variables.tf
@@ -130,3 +130,8 @@ variable "storage_class" {
   description = "Storage class to be used for all persistent disks. For a deployment on k3s use 'local-path'."
   default     = "pd-ssd"
 }
+
+variable "enable_telegraf_daemonset" {
+  description = "If true Telegraf client will run on all nodes. Set false for k3s single node deployment."
+  default     = "true"
+}

--- a/variables.tf
+++ b/variables.tf
@@ -135,3 +135,8 @@ variable "enable_telegraf_daemonset" {
   description = "If true Telegraf client will run on all nodes. Set false for k3s single node deployment."
   default     = "true"
 }
+
+variable "kafka_loadbalancers" {
+  description = "Number of Kafka loadbalancers. Must be less or equal to the number of Kafka brokers. Set to 1 for single node deployment with k3s."
+  default     = "3"
+}

--- a/variables.tf
+++ b/variables.tf
@@ -120,3 +120,8 @@ variable "prometheus_oauth_client_secret" {
 variable "kubeconfig_filename" {
   description = "kubeconfig file to configure kubernetes/helm providers"
 }
+
+variable "storage_class" {
+  description = "Storage class to be used for all persistent disks. For a deployment on k3s use 'local-path'."
+  default     = "pd-ssd"
+}

--- a/variables.tf
+++ b/variables.tf
@@ -78,6 +78,11 @@ variable "influxdb_admin_pass" {
   description = "influxdb admin account passphrase."
 }
 
+variable "influxdb_disk_size" {
+  description = "Disk size for InfluxDB."
+  default     = "128Gi"
+}
+
 variable "github_user" {
   description = "GitHub username for authenticating to the GitHub API."
 }


### PR DESCRIPTION
- Specify storage class for kafka, influxdb and prometheus-operator
- Specify size of influxdb disk
- Control if telegraf client is deployed as daemonset (false if deployed to single node with k3s)
- There was an assumption that the number of kafka loadbalancer services was the same as the number of brokers, and it was fixed to 3 in the terraform deployment. When doing single machine deployment we still can have n>1 brokers but only 1 loadbalancer. It is now possible to configure the number of kafka loadbalancer services.
